### PR TITLE
quarter_hourly: add disabled by default support

### DIFF
--- a/etc/crontab
+++ b/etc/crontab
@@ -16,6 +16,7 @@ PATH=/etc:/bin:/sbin:/usr/bin:/usr/sbin
 0	*	*	*	*	root	newsyslog
 #
 # Perform daily/weekly/monthly maintenance.
+#*/15	*	*	*	*	root	periodic quarter_hourly
 1	*	*	*	*	root	periodic hourly
 1	3	*	*	*	root	periodic daily
 15	4	*	*	6	root	periodic weekly

--- a/etc/periodic.conf
+++ b/etc/periodic.conf
@@ -10,6 +10,14 @@ hourly_zfs_snapshot_pools="tank"			# space seperated list of pools or datasets
 hourly_zfs_snapshot_keep=3
 hourly_zfs_snapshot_skip=""				# space seperated list of datasets to skip
 
+# Quarter hourly options
+
+# 000.zfs-snapshot
+#quarter_hourly_zfs_snapshot_enable="YES"
+#quarter_hourly_zfs_snapshot_pools="tank"
+#quarter_hourly_zfs_snapshot_keep=8
+#quarter_hourly_zfs_snapshot_skip=""
+
 # Daily options
 
 # 000.zfs-snapshot

--- a/etc/periodic/quarter_hourly/000.zfs-snapshot
+++ b/etc/periodic/quarter_hourly/000.zfs-snapshot
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# If there is a global system configuration file, suck it in.
+#
+if [ -r /etc/defaults/periodic.conf ]
+then
+    . /etc/defaults/periodic.conf
+    source_periodic_confs
+fi
+
+pools=$quarter_hourly_zfs_snapshot_pools
+if [ -z "$pools" ]; then
+    pools='tank'
+fi
+
+keep=$quarter_hourly_zfs_snapshot_keep
+if [ -z "$keep" ]; then
+    keep=8
+fi
+
+case "$quarter_hourly_zfs_snapshot_enable" in
+    [Yy][Ee][Ss])
+        . /etc/periodic/zfs-snapshot
+        do_snapshots "$pools" $keep 'quarter_hourly' "$quarter_hourly_zfs_snapshot_skip"
+        ;;
+    *)
+        ;;
+esac

--- a/etc/periodic/zfs-snapshot
+++ b/etc/periodic/zfs-snapshot
@@ -6,6 +6,9 @@ create_snapshot()
     pool=$1
 
     case "$type" in
+        quarter_hourly)
+        now=`date +"$type-%Y-%m-%d-%H-%M"`
+        ;;
         hourly)
         now=`date +"$type-%Y-%m-%d-%H"`
         ;;
@@ -71,6 +74,10 @@ do_pool()
     # create the regex matching the type of snapshots we're currently working
     # on
     case "$type" in
+        quarter_hourly)
+        # quarter_hourly-2009-01-01-00-15
+        regex="^$pool@$type-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9]$"
+        ;;
         hourly)
         # hourly-2009-01-01-00
         regex="^$pool@$type-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9]$"


### PR DESCRIPTION
Thank you for creating `zfs-periodic`, it has been incredibly useful over the years.

I have been using this patch for a long time to get more than one snapshot an hour, it could be useful to other people, even if just as documentation and not enabled by default.